### PR TITLE
Fix broken item% totals when powerups are cvar-replaced

### DIFF
--- a/src/actors/items/powerups.txt
+++ b/src/actors/items/powerups.txt
@@ -151,6 +151,7 @@ ACTOR ArgBlurSphere : BlurSphere replaces BlurSphere
 		Goto Super::Spawn
 	AltItem:
 		PINS A 0 A_SpawnItemEx("ArgQuadDamage", 0, 0, 0, 0, 0, 0, 0, SXF_NOCHECKPOSITION, 0, tid)
+		PINS A 0 Thing_Remove (0)
 		Stop
 	}
 }
@@ -165,6 +166,7 @@ ACTOR ArgInfrared : Infrared replaces Infrared
 		Goto Super::Spawn
 	AltItem:
 		PVIS A 0 A_SpawnItemEx("ArgHaste", 0, 0, 0, 0, 0, 0, 0, SXF_NOCHECKPOSITION, 0, tid)
+		PVIS A 0 Thing_Remove (0)
 		Stop
 	}
 }
@@ -179,6 +181,7 @@ ACTOR ArgSoulsphere : Soulsphere replaces Soulsphere
 		Goto Super::Spawn
 	AltItem:
 		SOUL A 0 A_SpawnItemEx("ArgRegen", 0, 0, 0, 0, 0, 0, 0, SXF_NOCHECKPOSITION, 0, tid)
+		SOUL A 0 Thing_Remove (0)
 		Stop
 	}
 }


### PR DESCRIPTION
ZDoom gets confused if a Stop is used to run off of the end of a
state, since Lost Souls and Pain Elementals do that after they die, so
it can't remove them from the end-tally since they still count that
way.

So for the cvar-based powerups, we need to explicitly tell ZDoom that
we want to remove them from the map so it knows to drop them from the
item% totals.
