### PR TITLE
Bfg ammotype revamp

### DIFF
--- a/src/actors/player.txt
+++ b/src/actors/player.txt
@@ -16,7 +16,7 @@ ACTOR ArgPlayer : DoomPlayer
 	Player.WeaponSlot 4, ArgHeavyAR, ArgChaingun
 	Player.WeaponSlot 5, ArgRocketLauncher
 	Player.WeaponSlot 6, ArgPlasmaRifle, ArgGaussCannon
-	Player.WeaponSlot 7, ArgBFG9000
+	Player.WeaponSlot 7, ArgBFG9000, ArgBFG9000Alt
 	
 	DamageFactor "ArgPlayerRocket", 0.5
 	DamageFactor "ArgBFGZapper", 0.0

--- a/src/actors/weapons/bfg.txt
+++ b/src/actors/weapons/bfg.txt
@@ -11,9 +11,10 @@ ACTOR ArgBFG9000 : ArgWeapon replaces BFG9000
 {
 	Weapon.UpSound "weapons/bfg/equip"
 	Weapon.SelectionOrder 11
-	Weapon.AmmoUse 0 // needs to be selectable at all times since ammotype is variable :<
+	Weapon.AmmoUse 1 // so you need at least 1 cell to select it
 	Weapon.AmmoGive 40
-	Weapon.AmmoType "Cell" // [TODO] give this its own ammotype
+	Weapon.AmmoType "Cell"
+	Weapon.SisterWeapon "ArgBFG9000Alt"
 	Inventory.Icon "graphics/hud/weapon-bfg.png"
 	Inventory.PickupMessage "$ARG_GOT_BFG"
 	Tag "$ARG_TAG_BFG"
@@ -27,7 +28,11 @@ ACTOR ArgBFG9000 : ArgWeapon replaces BFG9000
 		BFGG A 1 Bright A_WeaponReady
 		Loop
 	Select:
-		BFGG A 0 Bright
+		BFGG A 0 Bright {
+			if(GetCvar("arg_bfgammotype") == true) {
+				A_SelectWeapon("ArgBFG9000Alt");
+			}
+		}
 		Goto SelectLoop
 	Deselect:
 		BFGG A 0 Bright
@@ -35,14 +40,14 @@ ACTOR ArgBFG9000 : ArgWeapon replaces BFG9000
 	Fire:
 		BFGG A 1 Bright {
 			// overly complex ammo check function ohno
-			if((GetCvar("arg_bfgammotype") == false && GetCvar("arg_classicbfg") == true  && CountInv("Cell") < BFG_CLASSIC_AMMOUSE)
-			 ||(GetCvar("arg_bfgammotype") == false && GetCvar("arg_classicbfg") == false && CountInv("Cell") < BFG_MODERN_AMMOUSE )
-			 ||(GetCvar("arg_bfgammotype") == true  && CountInv("ArgBFGAmmo") < 1 )) {
+			if((GetCvar("arg_classicbfg") == true  && CountInv("Cell") < BFG_CLASSIC_AMMOUSE)
+			 ||(GetCvar("arg_classicbfg") == false && CountInv("Cell") < BFG_MODERN_AMMOUSE )) {
 				A_SelectWeapon("None", SWF_SELECTPRIORITY);
 			} else {
 				A_PlaySound("weapons/bfg/fire", CHAN_AUTO);
 			}
 		}
+	FireAnim:
 		BFGG B 1 Bright { A_WeaponOffset(frandom(-0.1, 0.1), frandom(-0.1, 0.1) + 32); A_Quake(1, 8, 0, 8, ""); }
 		BFGG C 1 Bright   A_WeaponOffset(frandom(-0.1, 0.1), frandom(-0.1, 0.1) + 32) 
 		BFGG D 1 Bright   A_WeaponOffset(frandom(-0.2, 0.2), frandom(-0.2, 0.2) + 32)
@@ -59,26 +64,20 @@ ACTOR ArgBFG9000 : ArgWeapon replaces BFG9000
 		BFGG K 1 Bright   A_WeaponOffset(frandom(-0.8, 0.8), frandom(-0.8, 0.8) + 32) 
 		BFGG L 1 Bright   A_WeaponOffset(frandom(-0.9, 0.9), frandom(-0.9, 0.9) + 32) 
 		BFGF A 1 Bright { A_WeaponOffset(frandom(-1.0, 1.0), frandom(-1.0, 1.0) + 32); A_Quake(3, 3, 0, 8, ""); }
-		BFGF B 1 Bright   A_WeaponOffset(0, 32)
+		BFGF B 1 Bright { A_WeaponOffset(0, 32); return state("DoFire"); }
+	DoFire:
 		BFGF C 0 Bright {
 			A_ZoomFactor(0.90, ZOOM_INSTANT|ZOOM_NOSCALETURNING);
 			if(GetCvar("arg_classicbfg") == true) {
 				A_FireCustomMissile("ArgThatDamnDragonAteMyBalls", 0, 0);
-				if(GetCvar("arg_bfgammotype") == true) {
-					A_TakeInventory("ArgBFGAmmo", 1);
-				} else {
-					A_TakeInventory("Cell", BFG_CLASSIC_AMMOUSE);
-				}
+				A_TakeInventory("Cell", BFG_CLASSIC_AMMOUSE);
 			} else {
 				A_FireCustomMissile("ArgIveGotBallsOfSteel", 0, 0);
-				if(GetCvar("arg_bfgammotype") == true) {
-					A_TakeInventory("ArgBFGAmmo", 1);
-				} else {
-					A_TakeInventory("Cell", BFG_MODERN_AMMOUSE);
-				}
+				A_TakeInventory("Cell", BFG_MODERN_AMMOUSE);
 			}
 			return A_Jump(64, "Fire2");
 		}
+	Fire1:
 		BFGF C 1 Bright A_ZoomFactor(0.91, ZOOM_INSTANT|ZOOM_NOSCALETURNING)
 		BFGF D 1 Bright A_ZoomFactor(0.92, ZOOM_INSTANT|ZOOM_NOSCALETURNING)
 		Goto FireEnd
@@ -110,6 +109,42 @@ ACTOR ArgBFG9000 : ArgWeapon replaces BFG9000
 		TNT1 A 2 Bright A_Light(2)
 		TNT1 A 2 Bright A_Light(1)
 		Goto LightDone
+	}
+}
+
+// custom ammo edition
+
+ACTOR ArgBFG9000Alt : ArgBFG9000 {
+	Weapon.AmmoUse 1
+	Weapon.AmmoGive 1
+	Weapon.AmmoType "ArgBFGAmmo"
+	Weapon.SisterWeapon "ArgBFG9000"
+
+	States
+	{
+	Select:
+		BFGG A 0 Bright {
+			if(GetCvar("arg_bfgammotype") == false) {
+				A_SelectWeapon("ArgBFG9000");
+			}
+		}
+		Goto SelectLoop
+	Fire:
+		BFGG A 1 Bright {
+			A_PlaySound("weapons/bfg/fire", CHAN_AUTO);
+		}
+		Goto FireAnim
+	DoFire:
+		BFGF C 0 Bright {
+			A_ZoomFactor(0.90, ZOOM_INSTANT|ZOOM_NOSCALETURNING);
+			if(GetCvar("arg_classicbfg") == true) {
+				A_FireCustomMissile("ArgThatDamnDragonAteMyBalls", 0, 1);
+			} else {
+				A_FireCustomMissile("ArgIveGotBallsOfSteel", 0, 1);
+			}
+			return A_Jump(64, "Fire2");
+		}
+		Goto Fire1
 	}
 }
 

--- a/src/actors/weapons/bfg.txt
+++ b/src/actors/weapons/bfg.txt
@@ -29,7 +29,7 @@ ACTOR ArgBFG9000 : ArgWeapon replaces BFG9000
 		Loop
 	Select:
 		BFGG A 0 Bright {
-			if(GetCvar("arg_bfgammotype") == true) {
+			if(CountInv("ArgBFG9000AmmoToken") > 0) {
 				A_SelectWeapon("ArgBFG9000Alt");
 			}
 		}
@@ -124,7 +124,7 @@ ACTOR ArgBFG9000Alt : ArgBFG9000 {
 	{
 	Select:
 		BFGG A 0 Bright {
-			if(GetCvar("arg_bfgammotype") == false) {
+			if(CountInv("ArgBFG9000AmmoToken") == 0) {
 				A_SelectWeapon("ArgBFG9000");
 			}
 		}
@@ -147,6 +147,8 @@ ACTOR ArgBFG9000Alt : ArgBFG9000 {
 		Goto Fire1
 	}
 }
+
+ACTOR ArgBFG9000AmmoToken : ArgToken {} 
 
 // classic mode
 

--- a/src/actors/weapons/bfg.txt
+++ b/src/actors/weapons/bfg.txt
@@ -119,6 +119,7 @@ ACTOR ArgBFG9000Alt : ArgBFG9000 {
 	Weapon.AmmoGive 1
 	Weapon.AmmoType "ArgBFGAmmo"
 	Weapon.SisterWeapon "ArgBFG9000"
+	Weapon.SelectionOrder 13
 
 	States
 	{

--- a/src/sbarinfo.txt
+++ b/src/sbarinfo.txt
@@ -23,35 +23,12 @@ statusbar fullscreen, fullscreenoffsets
 		DrawBar "graphics/hud/bar-armor-2.png", "graphics/hud/bar-armor-2x.png", armor(200), horizontal,  0, -55;
 		
 		// ammo
-		IsSelected NOT ArgBFG9000 {
-			DrawNumber 3, "hudfont-large", untranslated, ammo1, alignment(right), -96, -58;
-			InInventory Backpack, 1 {
-				DrawBar "graphics/hud/bar-ammo-1a.png", "graphics/hud/bar-ammo-1xa.png", ammo1, horizontal, reverse, -228, -41;
-				DrawBar "graphics/hud/bar-ammo-2.png" , "graphics/hud/bar-ammo-2x.png" , ammo1, horizontal, reverse, -162, -41;
-			} Else {
-				DrawBar "graphics/hud/bar-ammo-1.png", "graphics/hud/bar-ammo-1x.png", ammo1, horizontal, reverse, -162, -41;
-			}
-		}
-		
-		// bfg ammo -- hooray unfortunate copypasta
-		Else {
-			IfCVarInt NOT arg_bfgammotype, 1 {
-				DrawNumber 3, "hudfont-large", untranslated, ammo1, alignment(right), -96, -58;
-				InInventory Backpack, 1  {
-					DrawBar "graphics/hud/bar-ammo-1a.png", "graphics/hud/bar-ammo-1xa.png", ammo1, horizontal, reverse, -228, -41;
-					DrawBar "graphics/hud/bar-ammo-2.png" , "graphics/hud/bar-ammo-2x.png" , ammo1, horizontal, reverse, -162, -41;
-				} Else {
-					DrawBar "graphics/hud/bar-ammo-1.png", "graphics/hud/bar-ammo-1x.png", ammo1, horizontal, reverse, -162, -41;
-				}
-			} Else {
-				DrawNumber 3, "hudfont-large", untranslated, ArgBFGAmmo, alignment(right), -96, -58;
-				InInventory Backpack, 1 {
-					DrawBar "graphics/hud/bar-ammo-1a.png", "graphics/hud/bar-ammo-1xa.png", ArgBFGAmmo, horizontal, reverse, -228, -41;
-					DrawBar "graphics/hud/bar-ammo-2.png" , "graphics/hud/bar-ammo-2x.png" , ArgBFGAmmo, horizontal, reverse, -162, -41;
-				} Else {
-					DrawBar "graphics/hud/bar-ammo-1.png", "graphics/hud/bar-ammo-1x.png", ArgBFGAmmo, horizontal, reverse, -162, -41;
-				}
-			}
+		DrawNumber 3, "hudfont-large", untranslated, ammo1, alignment(right), -96, -58;
+		InInventory Backpack, 1 {
+			DrawBar "graphics/hud/bar-ammo-1a.png", "graphics/hud/bar-ammo-1xa.png", ammo1, horizontal, reverse, -228, -41;
+			DrawBar "graphics/hud/bar-ammo-2.png" , "graphics/hud/bar-ammo-2x.png" , ammo1, horizontal, reverse, -162, -41;
+		} Else {
+			DrawBar "graphics/hud/bar-ammo-1.png", "graphics/hud/bar-ammo-1x.png", ammo1, horizontal, reverse, -162, -41;
 		}
 		
 		// equipment

--- a/src/scripts/argent.acs
+++ b/src/scripts/argent.acs
@@ -39,6 +39,36 @@ script "ArgentInit" enter {
 	,	DEF_DUMMY_TID // targetTidOrig
 	};
 	players[PlayerNumber()] = playerStruct;
+	
+	// Remove all cooldowns on map start. This will eventually go away
+	// once the cooldown system is redone to use overlays.
+	TakeInventory("ArgShotgunModCooldown"       , 999);
+	TakeInventory("ArgHeavyARModCooldown"       , 999);
+	TakeInventory("ArgChaingunModCooldown"      , 999);
+	TakeInventory("ArgRocketLauncherModCooldown", 999);
+	TakeInventory("ArgPlasmaRifleModCooldown"   , 999);
+	TakeInventory("ArgGaussCannonModCooldown"   , 999);
+	TakeInventory("ArgGaussCannonModCharge"     , 999);
+	
+	// BFG management. Give the player a token item to determine whether we
+	// want to use regular cells or BFG cells; we want to check for this item
+	// in the weapon defs rather than the cvar directly since we want to
+	// only fully-change this setting on map-start.
+	if(GetCvar("arg_bfgammotype") == true) {
+		// use bfg cells
+		GiveInventory("ArgBFG9000AmmoToken", 1);
+		// select correct weapon
+		if(StrICmp(GetWeapon(), "ArgBFG9000") == 0) {
+			SetWeapon("ArgBFG9000Alt");
+		}
+	} else {
+		// use regular cells
+		TakeInventory("ArgBFG9000AmmoToken", 1);
+		// select correct weapon
+		if(StrICmp(GetWeapon(), "ArgBFG9000Alt") == 0) {
+			SetWeapon("ArgBFG9000");
+		}
+	}
 }
 
 /*
@@ -319,20 +349,6 @@ script "ClearModCooldown" (void) {
 	str weapon = GetWeapon();
 	str modCooldownToken = StrParam(s:weapon, s:"ModCooldown");
 	TakeInventory(modCooldownToken, 999);
-}
-
-/*
- * Removes all cooldowns on map start.
- */
-script "ClearCooldownsOnStart" enter {
-	// [XA] bit stiff in the code here, but it works.
-	TakeInventory("ArgShotgunModCooldown"       , 999);
-	TakeInventory("ArgHeavyARModCooldown"       , 999);
-	TakeInventory("ArgChaingunModCooldown"      , 999);
-	TakeInventory("ArgRocketLauncherModCooldown", 999);
-	TakeInventory("ArgPlasmaRifleModCooldown"   , 999);
-	TakeInventory("ArgGaussCannonModCooldown"   , 999);
-	TakeInventory("ArgGaussCannonModCharge"     , 999);
 }
 
 /*


### PR DESCRIPTION
Closes #5. Went ahead and made 'em two separate weapons.

Technically, there's still one tiny glitch-up: in BFG Cells mode, you can repeatedly re-select the BFG by pressing 7. Really it's no big deal, and hacking around it would be a PITA.